### PR TITLE
fix: add CookieOptions type to resolve Vercel build failure

### DIFF
--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,4 +1,4 @@
-import { createServerClient } from '@supabase/ssr'
+import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
 export function createClient() {
@@ -12,7 +12,7 @@ export function createClient() {
         getAll() {
           return cookieStore.getAll()
         },
-        setAll(cookiesToSet) {
+        setAll(cookiesToSet: { name: string; value: string; options: CookieOptions }[]) {
           try {
             cookiesToSet.forEach(({ name, value, options }) =>
               cookieStore.set(name, value, options)


### PR DESCRIPTION
Fixes implicit 'any' type error on `cookiesToSet` parameter in `lib/supabase/server.ts`.

Imports `CookieOptions` from `@supabase/ssr` to satisfy strict TypeScript config.

Closes #3

Generated with [Claude Code](https://claude.ai/code)